### PR TITLE
Fix fab button stuck on screen

### DIFF
--- a/src/components/Portal/PortalConsumer.tsx
+++ b/src/components/Portal/PortalConsumer.tsx
@@ -25,7 +25,7 @@ export default class PortalConsumer extends React.Component<Props> {
 
     // Because of the delay in componentDidMount, componentDidUpdate
     // can run before a key is set causing corrupt data in the manager.
-    if (this.key) {
+    if (this.key !== undefined) {
       this.props.manager.update(
         this.key,
         this.props.children,


### PR DESCRIPTION
In the seer mobile app FAB buttons were getting stuck on the screen due to portal consumers being issued a 0 key and being excluded from updates.