### PR TITLE
feat: add text wrapper style prop for chip component

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -76,6 +76,10 @@ type Props = React.ComponentProps<typeof Surface> & {
    */
   textStyle?: any;
   style?: StyleProp<ViewStyle>;
+  /**
+   * Style of chip's text wrapper
+   */
+  textWrapperStyle?: StyleProp<ViewStyle>;
 
   /**
    * @optional
@@ -130,6 +134,7 @@ const Chip = ({
   onLongPress,
   onClose,
   textStyle,
+  textWrapperStyle,
   style,
   theme,
   testID,
@@ -257,7 +262,13 @@ const Chip = ({
         accessibilityState={accessibilityState}
         testID={testID}
       >
-        <View style={[styles.content, { paddingRight: onClose ? 32 : 4 }]}>
+        <View
+          style={[
+            styles.content,
+            { paddingRight: onClose ? 32 : 4 },
+            textWrapperStyle,
+          ]}
+        >
           {avatar && !icon ? (
             <View style={[styles.avatarWrapper, disabled && { opacity: 0.26 }]}>
               {React.isValidElement(avatar)

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -59,6 +59,7 @@ exports[`renders chip with close button 1`] = `
           Object {
             "paddingRight": 32,
           },
+          undefined,
         ]
       }
     >
@@ -281,6 +282,7 @@ exports[`renders chip with icon 1`] = `
           Object {
             "paddingRight": 4,
           },
+          undefined,
         ]
       }
     >
@@ -430,6 +432,7 @@ exports[`renders chip with onPress 1`] = `
           Object {
             "paddingRight": 4,
           },
+          undefined,
         ]
       }
     >
@@ -531,6 +534,7 @@ exports[`renders outlined disabled chip 1`] = `
           Object {
             "paddingRight": 4,
           },
+          undefined,
         ]
       }
     >
@@ -632,6 +636,7 @@ exports[`renders selected chip 1`] = `
           Object {
             "paddingRight": 4,
           },
+          undefined,
         ]
       }
     >

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -142,6 +142,7 @@ exports[`renders list item with custom description 1`] = `
                     Object {
                       "paddingRight": 4,
                     },
+                    undefined,
                   ]
                 }
               >


### PR DESCRIPTION
This PR adds a `textWrapperStyle` prop to help give more control of the styling of Chip component.