### PR TITLE
feat: add hitslop prop to chip component

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -135,6 +135,7 @@ const Chip = ({
   onClose,
   textStyle,
   textWrapperStyle,
+  hitSlop,
   style,
   theme,
   testID,
@@ -252,6 +253,7 @@ const Chip = ({
         onLongPress={onLongPress}
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
+        hitSlop={hitSlop}
         underlayColor={underlayColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}


### PR DESCRIPTION
Chip components tend to be smaller than the recommended touch areas. This allows passing a hitslop to it to increase the touch area.