### PR TITLE
Fix multiline text inputs not aligning to vertical top

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -78,6 +78,8 @@ const TextInputExample = () => {
     maxLengthName,
     flatTextSecureEntry,
     outlineTextSecureEntry,
+    flatMultilineCustomHeightNoLabel,
+    flatMultilineCustomHeightNoLabelTop,
     iconsColor: {
       flatLeftIcon,
       flatRightIcon,
@@ -442,6 +444,30 @@ const TextInputExample = () => {
               roundness: 25,
             }}
             label="Custom rounded input"
+          />
+        </View>
+        <View style={styles.inputContainerStyle}>
+          <TextInput
+            style={[styles.inputContainerStyle, { height: 150 }]}
+            multiline
+            placeholder="Custom height, no label"
+            value={flatMultilineCustomHeightNoLabel}
+            onChangeText={(flatMultilineCustomHeightNoLabel) =>
+              inputActionHandler(
+                'flatMultilineCustomHeightNoLabel',
+                flatMultilineCustomHeightNoLabel
+              )
+            }
+          />
+          <TextInput
+            style={[styles.inputContainerStyle, { height: 150 }]}
+            multiline
+            placeholder="Custom height, no label, textAlignVertical to top"
+            textAlignVertical="top"
+            value={flatMultilineCustomHeightNoLabelTop}
+            onChangeText={(flatMultilineCustomHeightNoLabelTop) =>
+              inputActionHandler('flatMultilineCustomHeightNoLabelTop', flatMultilineCustomHeightNoLabelTop)
+            }
           />
         </View>
       </ScreenWrapper>

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -28,6 +28,10 @@ const initialState: State = {
   maxLengthName: '',
   flatTextSecureEntry: true,
   outlineTextSecureEntry: true,
+  flatMultilineCustomHeightNoLabel: '',
+  flatMultilineCustomHeightNoLabelTop: '',
+  outlinedMultilineCustomHeightNoLabel: '',
+  outlinedMultilineCustomHeightNoLabelTop: '',
   iconsColor: {
     flatLeftIcon: undefined,
     flatRightIcon: undefined,
@@ -80,6 +84,8 @@ const TextInputExample = () => {
     outlineTextSecureEntry,
     flatMultilineCustomHeightNoLabel,
     flatMultilineCustomHeightNoLabelTop,
+    outlinedMultilineCustomHeightNoLabel,
+    outlinedMultilineCustomHeightNoLabelTop,
     iconsColor: {
       flatLeftIcon,
       flatRightIcon,
@@ -466,7 +472,23 @@ const TextInputExample = () => {
             textAlignVertical="top"
             value={flatMultilineCustomHeightNoLabelTop}
             onChangeText={(flatMultilineCustomHeightNoLabelTop) =>
-              inputActionHandler('flatMultilineCustomHeightNoLabelTop', flatMultilineCustomHeightNoLabelTop)
+              inputActionHandler(
+                'flatMultilineCustomHeightNoLabelTop',
+                flatMultilineCustomHeightNoLabelTop
+              )
+            }
+          />
+          <TextInput
+            mode="outlined"
+            style={[styles.inputContainerStyle, { height: 150 }]}
+            multiline
+            placeholder="Custom height, outlined, no label"
+            value={outlinedMultilineCustomHeightNoLabel}
+            onChangeText={(outlinedMultilineCustomHeightNoLabel) =>
+              inputActionHandler(
+                'outlinedMultilineCustomHeightNoLabel',
+                outlinedMultilineCustomHeightNoLabel
+              )
             }
           />
         </View>

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -31,7 +31,6 @@ const initialState: State = {
   flatMultilineCustomHeightNoLabel: '',
   flatMultilineCustomHeightNoLabelTop: '',
   outlinedMultilineCustomHeightNoLabel: '',
-  outlinedMultilineCustomHeightNoLabelTop: '',
   iconsColor: {
     flatLeftIcon: undefined,
     flatRightIcon: undefined,
@@ -85,7 +84,6 @@ const TextInputExample = () => {
     flatMultilineCustomHeightNoLabel,
     flatMultilineCustomHeightNoLabelTop,
     outlinedMultilineCustomHeightNoLabel,
-    outlinedMultilineCustomHeightNoLabelTop,
     iconsColor: {
       flatLeftIcon,
       flatRightIcon,
@@ -452,7 +450,6 @@ const TextInputExample = () => {
             label="Custom rounded input"
           />
         </View>
-        <View style={styles.inputContainerStyle}>
           <TextInput
             style={[styles.inputContainerStyle, { height: 150 }]}
             multiline
@@ -491,7 +488,6 @@ const TextInputExample = () => {
               )
             }
           />
-        </View>
       </ScreenWrapper>
     </TextInputAvoidingView>
   );

--- a/example/utils/index.ts
+++ b/example/utils/index.ts
@@ -33,6 +33,8 @@ export type State = {
   flatTextSecureEntry: boolean;
   outlineTextSecureEntry: boolean;
   iconsColor: IconsColor;
+  flatMultilineCustomHeightNoLabel: string;
+  flatMultilineCustomHeightNoLabelTop: string;
 };
 
 export function inputReducer<T extends keyof State>(

--- a/example/utils/index.ts
+++ b/example/utils/index.ts
@@ -35,6 +35,8 @@ export type State = {
   iconsColor: IconsColor;
   flatMultilineCustomHeightNoLabel: string;
   flatMultilineCustomHeightNoLabelTop: string;
+  outlinedMultilineCustomHeightNoLabel: string;
+  outlinedMultilineCustomHeightNoLabelTop: string;
 };
 
 export function inputReducer<T extends keyof State>(

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -220,6 +220,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
 
     const paddingFlat = adjustPaddingFlat({
       ...paddingSettings,
+      textAlignVertical: rest.textAlignVertical,
       pad,
     });
 

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -182,7 +182,11 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
 
     const pad = calculatePadding(paddingSettings);
 
-    const paddingOut = adjustPaddingOut({ ...paddingSettings, pad });
+    const paddingOut = adjustPaddingOut({
+      ...paddingSettings,
+      textAlignVertical: rest.textAlignVertical,
+      pad,
+    });
 
     const baseLabelTranslateY =
       -labelHalfHeight - (topPosition + OUTLINE_MINIMIZED_LABEL_Y_OFFSET);

--- a/src/components/TextInput/helpers.tsx
+++ b/src/components/TextInput/helpers.tsx
@@ -7,6 +7,7 @@ import {
   FLAT_INPUT_OFFSET,
 } from './constants';
 import { AdornmentType, AdornmentSide } from './Adornment/enums';
+import type { TextInputProps } from './TextInput';
 
 type PaddingProps = {
   height: number | null;
@@ -24,6 +25,7 @@ type PaddingProps = {
 };
 
 type AdjProps = PaddingProps & {
+  textAlignVertical: TextInputProps['textAlignVertical'];
   pad: number;
 };
 
@@ -150,6 +152,7 @@ export const adjustPaddingFlat = ({
   dense,
   fontSize,
   isAndroid,
+  textAlignVertical,
   styles,
 }: AdjProps): Padding => {
   let result = pad;
@@ -190,7 +193,7 @@ export const adjustPaddingFlat = ({
     }
     topResult = Math.floor(topResult);
   } else {
-    if (height) {
+    if (height && (!textAlignVertical || textAlignVertical === 'center')) {
       // center text when height is passed
       return {
         paddingTop: Math.max(0, (height - fontSize) / 2),


### PR DESCRIPTION
`react-native-paper` has a bug which forces multiline inputs to always align to vertical middle (it provides padding top and bottom to the input regardless of the vertical alignment setting).

This patch allows us to vertically align multiline inputs to the top. Might be worth doing a patch contribution to main repo in 10% time but going through the github issues for `react-native-paper` either it's already fixed in current release or the maintainers aren't that excited about fixing this bug whilst there's a workaround (which is to redefine the render prop).