### PR TITLE
Add configurable header alignment

### DIFF
--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -17,6 +17,7 @@ const AppbarExample = ({ navigation }: Props) => {
   const [showMoreIcon, setShowMoreIcon] = React.useState(true);
   const [showCustomColor, setShowCustomColor] = React.useState(false);
   const [showExactTheme, setShowExactTheme] = React.useState(false);
+  const [leftAlign, setLeftAlign] = React.useState(false);
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
@@ -26,6 +27,7 @@ const AppbarExample = ({ navigation }: Props) => {
           theme={{
             mode: showExactTheme ? 'exact' : 'adaptive',
           }}
+          contentAlignment={leftAlign ? 'left' : 'center'}
         >
           {showLeftIcon && (
             <Appbar.BackAction onPress={() => navigation.goBack()} />
@@ -51,6 +53,7 @@ const AppbarExample = ({ navigation }: Props) => {
     showMoreIcon,
     showCustomColor,
     showExactTheme,
+    leftAlign,
   ]);
 
   return (
@@ -83,10 +86,15 @@ const AppbarExample = ({ navigation }: Props) => {
           <Paragraph>Exact Dark Theme</Paragraph>
           <Switch value={showExactTheme} onValueChange={setShowExactTheme} />
         </View>
+        <View style={styles.row}>
+          <Paragraph>Left Align</Paragraph>
+          <Switch value={leftAlign} onValueChange={setLeftAlign} />
+        </View>
       </ScreenWrapper>
       <Appbar
         style={styles.bottom}
         theme={{ mode: showExactTheme ? 'exact' : 'adaptive' }}
+        contentAlignment={leftAlign ? 'left' : 'auto'}
       >
         <Appbar.Action icon="archive" onPress={() => {}} />
         <Appbar.Action icon="email" onPress={() => {}} />

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -24,6 +24,7 @@ type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
    */
   theme: ReactNativePaper.Theme;
   style?: StyleProp<ViewStyle>;
+  contentAlignment?: 'auto' | 'left' | 'center';
 };
 
 export const DEFAULT_APPBAR_HEIGHT = 56;
@@ -73,7 +74,14 @@ export const DEFAULT_APPBAR_HEIGHT = 56;
  * });
  * ```
  */
-const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
+const Appbar = ({
+  children,
+  dark,
+  style,
+  theme,
+  contentAlignment = 'auto',
+  ...rest
+}: Props) => {
   const { colors, dark: isDarkTheme, mode } = theme;
   const {
     backgroundColor: customBackground,
@@ -102,7 +110,10 @@ const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
   let shouldCenterContent = false;
   let shouldAddLeftSpacing = false;
   let shouldAddRightSpacing = false;
-  if (Platform.OS === 'ios') {
+  if (
+    (Platform.OS === 'ios' && contentAlignment === 'auto') ||
+    contentAlignment === 'center'
+  ) {
     let hasAppbarContent = false;
     let leftItemsCount = 0;
     let rightItemsCount = 0;


### PR DESCRIPTION
Adds left alignment option for iOS appbar header. In the demo keep in mind you'll need to disable a bunch of actions for it to center align in ios in the first place, after which you can left align it using the toggle.