### PR TITLE
Fix android tap to select

### DIFF
--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -280,18 +280,20 @@ const FABGroup = ({
 
   return (
     <View pointerEvents="box-none" style={[styles.container, style]}>
-      <TouchableWithoutFeedback onPress={close}>
-        <Animated.View
-          pointerEvents={open ? 'auto' : 'none'}
-          style={[
-            styles.backdrop,
-            {
-              opacity: backdropOpacity,
-              backgroundColor: colors.backdrop,
-            },
-          ]}
-        />
-      </TouchableWithoutFeedback>
+      {open && (
+        <TouchableWithoutFeedback onPress={close}>
+          <Animated.View
+            pointerEvents={open ? 'auto' : 'none'}
+            style={[
+              styles.backdrop,
+              {
+                opacity: backdropOpacity,
+                backgroundColor: colors.backdrop,
+              },
+            ]}
+          />
+        </TouchableWithoutFeedback>
+      )}
       <SafeAreaView pointerEvents="box-none" style={styles.safeArea}>
         <View pointerEvents={open ? 'box-none' : 'none'}>
           {actions.map((it, i) => (


### PR DESCRIPTION
Addresses [Seer-2952](https://seermedical.atlassian.net/browse/SEER-2952).

`FABGroup` was causing an a11y issue, because it renders a `TouchableWithoutFeedback` element that covers the whole screen and prevents tapping to select in Android accessibility mode.

This PR updates `FABGroup` so that it only renders the `TouchableWithoutFeedback` when the FAB Group is open (e.g. after long pressing the "Report" button), when you really do want to prevent the underlying elements from being selected.