### PR TITLE
Remove FAB when not visible

### DIFF
--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -141,9 +141,11 @@ const FAB = ({
     new Animated.Value(visible ? 1 : 0)
   );
   const { scale } = theme.animation;
+  const [showFAB, setShowFAB] = React.useState<boolean>(true);
 
   React.useEffect(() => {
     if (visible) {
+      setShowFAB(true);
       Animated.timing(visibility, {
         toValue: 1,
         duration: 200 * scale,
@@ -154,7 +156,7 @@ const FAB = ({
         toValue: 0,
         duration: 150 * scale,
         useNativeDriver: true,
-      }).start();
+      }).start(() => setShowFAB(false));
     }
   }, [visible, scale, visibility]);
 
@@ -188,7 +190,7 @@ const FAB = ({
 
   const rippleColor = color(foregroundColor).alpha(0.32).rgb().string();
 
-  return (
+  return showFAB ? (
     <Surface
       {...rest}
       style={
@@ -252,6 +254,8 @@ const FAB = ({
         </View>
       </TouchableRipple>
     </Surface>
+  ) : (
+    <></>
   );
 };
 


### PR DESCRIPTION
Although https://github.com/seermedical/seer-mobile-app-patches--react-native-paper/pull/26 improved Android tap to select, it turns out there was still a minor issue. Namely, tap to select was still unavailable in areas on the screen where the FAB would be, on pages where the FAB is not visible.

![a11y](https://user-images.githubusercontent.com/51605204/161203251-246c50f6-a208-4c8f-9625-57bc33a7f0e5.png)

The proposed solution is to remove the FAB entirely when it is not visible. That is, the FAB will be removed once it has finished animating out and will be re-added before it animates in.